### PR TITLE
Python 3 compatibility

### DIFF
--- a/latextree/__init__.py
+++ b/latextree/__init__.py
@@ -20,8 +20,8 @@ __version__ = '0.1'
 
 import sys
 
-from document import LatexDocument
-from parser import LatexParser
+from .document import LatexDocument
+from .parser import LatexParser
 
 def load(latex_file, parser=None):
     """

--- a/latextree/bibliography.py
+++ b/latextree/bibliography.py
@@ -9,9 +9,9 @@ We use NodeFactory for unlisted fields
 
 import re, bibtexparser
 
-from factory import NodeFactory
-from node import LatexTreeNode
-from content import Text
+from .factory import NodeFactory
+from .node import LatexTreeNode
+from .content import Text
 
 class BibItem(LatexTreeNode):
 
@@ -113,12 +113,12 @@ def main(args=None):
         text = bibtex_file.read()
         
     bib = Bibliography(text)
-    print bib.harvard()
+    print(bib.harvard())
       
     # xml output
     from lxml import etree
     bibx = bib.xml() 
-    print etree.tostring(bibx, pretty_print=True)
+    print(etree.tostring(bibx, pretty_print=True))
 
 if __name__ == '__main__':
     main()

--- a/latextree/content.py
+++ b/latextree/content.py
@@ -3,10 +3,10 @@ content.py
 Content nodes for LatexTree objects
 """
 
-from node import LatexTreeNode
+from .node import LatexTreeNode
 
 class Content(LatexTreeNode):
-    '''
+    r'''
     Abstract class for content nodes.
     
     Media (content=`src`): from \includevideo{src}
@@ -192,14 +192,14 @@ class LatexTreeLink(LatexTreeNode):
 
 #------------------------------------------------
 def main():
-    print "content.py"
+    print("content.py")
     
     mama = LatexTreeNode()
     c1 = Text(text='hello ')
     c2 = Latex(latex=r'$\alpha+\beta$')
     c3 = Text(text=' goodbye.')
     mama.children = [c1, c2, c3]
-    print mama.show()
+    print(mama.show())
       
 if __name__ == '__main__':
     main()

--- a/latextree/document.py
+++ b/latextree/document.py
@@ -24,7 +24,7 @@ Example
 import os
 from jinja2 import Environment, FileSystemLoader
 
-import settings
+from . import settings
 
 import logging
 logger = logging.getLogger(__name__)
@@ -217,7 +217,7 @@ class LatexDocument(object):
         output = template.render(context)
         output_file = os.path.join(WEB_ROOT, 'index.html')
         with open(output_file, "wb") as f:
-            f.write(output)
+            f.write(output.encode('utf-8'))
 
         #--------------------------
         # create chapter pages (assumes that chapters are ordered correctly)
@@ -233,7 +233,7 @@ class LatexDocument(object):
             output = template.render(context)
             output_file = os.path.join(WEB_ROOT, make_url(chapter, include_label=False))
             with open(output_file, "wb") as f:
-                f.write(output)
+                f.write(output.encode('utf-8'))
         
         #--------------------------
         # create section pages (assumes that sections are ordered correctly)
@@ -251,7 +251,7 @@ class LatexDocument(object):
                     output = template.render(context)
                     output_file = os.path.join(WEB_ROOT, make_url(section, include_label=False))
                     with open(output_file, "wb") as f:
-                        f.write(output)
+                        f.write(output.encode('utf-8'))
             # if bibliography:
             #     context["prv"] = chapters[-1] if chapters else None
             #     context["nxt"] = None
@@ -269,7 +269,7 @@ class LatexDocument(object):
                 output = template.render(context)
                 output_file = os.path.join(WEB_ROOT, make_url(section, include_label=False))
                 with open(output_file, "wb") as f:
-                    f.write(output)
+                    f.write(output.encode('utf-8'))
             # if bibliography:
             #     context["prv"] = sections[-1] if sections else None
             #     context["nxt"] = None
@@ -291,7 +291,7 @@ class LatexDocument(object):
             output = template.render(context)
             output_file = os.path.join(WEB_ROOT, 'bibliography.html')
             with open(output_file, "wb") as f:
-                f.write(output)
+                f.write(output.encode('utf-8'))
         
         #--------------------------
         # copy static files to WEB_ROOT
@@ -477,7 +477,7 @@ class LatexDocument(object):
                                 
 #------------------------------------------------
 def main():
-    print "latextree.document.py"
+    print("latextree.document.py")
     
     from utils import read_latex_document
     from parser import LatexParser
@@ -534,15 +534,15 @@ def main():
     
     pa = LatexParser()
     for idx, s in enumerate(tests):
-        print '=================================='
-        print 'TEST %d' % idx
+        print('==================================')
+        print('TEST %d' % idx)
         doc = pa.parse_latex_document(s, insert_strict_braces=True, non_breaking_spaces=True)
         from lxml import etree
-        print '------------------------'
-        print etree.tostring(doc.root.get_xml(), pretty_print=True)
-        print '------------------------'
-        print doc.bbq()
-        print '--------------------'
+        print('------------------------')
+        print(etree.tostring(doc.root.get_xml(), pretty_print=True))
+        print('------------------------')
+        print(doc.bbq())
+        print('--------------------')
 
     # return None
 
@@ -556,24 +556,24 @@ def main():
 
     # output
     from lxml import etree
-    print etree.tostring(doc.root.get_xml(), pretty_print=True)
+    print(etree.tostring(doc.root.get_xml(), pretty_print=True))
     # from lxml.html import tostring
-    # print tostring(doc.root.get_xml(), pretty_print=True)
-    # print '--------------------'
-    # print doc.root.show()
-    print '--------------------'
-    print 'Preamble:'
-    print doc.preamble
-    print '--------------------'
-    print 'Blackboard questions:'
-    print doc.bbq()
-    print '--------------------'
-    print 'Labelled nodes:'
-    print doc.xrefs
-    print '--------------------'
-    print 'Website:'
-    print doc.make_website()
-    print '--------------------'
+    # print(tostring(doc.root.get_xml(), pretty_print=True))
+    # print('--------------------')
+    # print(doc.root.show())
+    print('--------------------')
+    print('Preamble:')
+    print(doc.preamble)
+    print('--------------------')
+    print('Blackboard questions:')
+    print(doc.bbq())
+    print('--------------------')
+    print('Labelled nodes:')
+    print(doc.xrefs)
+    print('--------------------')
+    print('Website:')
+    print(doc.make_website())
+    print('--------------------')
     
 if __name__ == '__main__':
     main()

--- a/latextree/factory.py
+++ b/latextree/factory.py
@@ -4,7 +4,7 @@ Created on Thu Apr 27 07:02:26 2017
 @author: scmde
 """
 
-from node import LatexTreeNode
+from .node import LatexTreeNode
   
 def ClassFactory(name, argnames, BaseClass=LatexTreeNode):
     '''
@@ -44,9 +44,9 @@ def main():
     classes.update(environment_classes)
     classes.update(switch_classes)
 
-    print classes
-    print abstract_switch_classes
-    print switch_classes
+    print(classes)
+    print(abstract_switch_classes)
+    print(switch_classes)
     
 
 if __name__ == '__main__':

--- a/latextree/ltree.py
+++ b/latextree/ltree.py
@@ -6,9 +6,9 @@ This module provides command line tools for LatexTree.
 import sys
 from optparse import OptionParser
 
-from reader import read_latex_document
-from node import LatexTreeNode
-import taxonomy as tax
+from .reader import read_latex_document
+from .node import LatexTreeNode
+from . import taxonomy as tax
 
 import logging
 log = logging.getLogger(__name__)
@@ -20,19 +20,19 @@ def main(args=None):
     oparser = OptionParser(usage="%prog main.tex [-opts]", version="%prog: version 1.0", add_help_option=True)
     oparser.add_option("-b", "--bbq", action="store_true", dest="bbq", help="typeset questions in blackboard format")
     oparser.add_option("-e", "--exex", action="store_true", dest="exex", help="extract and typeset exercises")
-    oparser.add_option("-i", "--info", action="store_true", dest="info", help="print document info to stdout")
-    oparser.add_option("-c", "--xrefs", action="store_true", dest="xrefs", help="print (label, entity) pairs to stdout")
+    oparser.add_option("-i", "--info", action="store_true", dest="info", help="print(document info to stdout"))
+    oparser.add_option("-c", "--xrefs", action="store_true", dest="xrefs", help="print((label, entity) pairs to stdout"))
     oparser.add_option("-p", "--pdf", action="store_true", dest="pdf", help=" create pdf")
-    oparser.add_option("-s", "--show", action="store_true", dest="show", help=" print tree to stdout (recursive)")
+    oparser.add_option("-s", "--show", action="store_true", dest="show", help=" print(tree to stdout (recursive)"))
     oparser.add_option("-v", "--verbose", action="store_false", dest="verbose", help="verbose output")
     oparser.add_option("-w", "--web", action="store_true", dest="web", help="create standalone website")
-    oparser.add_option("-x", "--xml", action="store_true", dest="xml", help="print xml tree to stdout")
+    oparser.add_option("-x", "--xml", action="store_true", dest="xml", help="print(xml tree to stdout"))
     oparser.set_defaults(verbose=True, tex=False, html=False, xml=False)
 
     # parse arguments
     (options, args) = oparser.parse_args()
     if not args:
-        print 'usage: $ltree.py main.tex [opts]'
+        print('usage: $ltree.py main.tex [opts]')
         return
 
     # parse document
@@ -43,12 +43,12 @@ def main(args=None):
 
     # show tree (recursive)
     if options.show:
-        print doc.root.show()
+        print(doc.root.show())
 
     # xml
     if options.xml:
         from lxml import etree        
-        print etree.tostring(doc.root.get_xml(), pretty_print=True)
+        print(etree.tostring(doc.root.get_xml(), pretty_print=True))
 
     # blackboard questions
     if options.bbq:
@@ -64,30 +64,30 @@ def main(args=None):
         exercises = doc.body.get_phenotypes('exercise')
         if exercises:
             for ex in exercises:
-                print etree.tostring(ex.xml(), pretty_print=True)
+                print(etree.tostring(ex.xml(), pretty_print=True))
         else:
-            print 'No exercises!'
+            print('No exercises!')
 
-    # print doccument information
+    # print(doccument information)
     if options.info:
-        print '=============================='
-        print 'Document information'
-        print '------------------------------'
+        print('==============================')
+        print('Document information')
+        print('------------------------------')
         for param in tax.preamble_capture:
-            print "%s: %s" % (param.ljust(15), doc.preamble[param] if param in doc.preamble else '')
-        print '=============================='
+            print("%s: %s" % (param.ljust(15), doc.preamble[param] if param in doc.preamble else ''))
+        print('==============================')
 
-    # print xrefs
+    # print(xrefs)
     if options.xrefs:
         col_width = max( [len(key) for key in doc.xrefs.keys()] ) + 2  # padding
-        print '=============================='
-        print 'Labels'
-        print '=============================='
-        print 'Label'.ljust(col_width) + 'TreeNode'
-        print '------------------------------'
+        print('==============================')
+        print('Labels')
+        print('==============================')
+        print('Label'.ljust(col_width) + 'TreeNode')
+        print('------------------------------')
         for key, val in doc.xrefs.items():
-            print key.ljust(col_width) + repr(val)
-        print '=============================='
+            print(key.ljust(col_width) + repr(val))
+        print('==============================')
 
 if __name__ == '__main__':
     main()

--- a/latextree/node.py
+++ b/latextree/node.py
@@ -8,7 +8,7 @@ Families are subclassed into genera: Level, List, etc.
 Genera are subclassed into species: Chapter, Section etc. or Itemize, Enumerate, etc.
 """
 
-import taxonomy as tax
+from . import taxonomy as tax
 
 import logging
 logger = logging.getLogger(__name__)
@@ -436,7 +436,7 @@ class Switch(LatexTreeNode):
             
 #------------------------------------------------
 def main(args=None):
-    print "node.py"
+    print("node.py")
     root = LatexTreeNode()
     n1 = LatexTreeNode()
     n1.number = 5
@@ -452,16 +452,16 @@ def main(args=None):
     n2.title = n3
     from lxml import etree
     xtree = root.get_xml()
-    print etree.tostring(xtree, pretty_print=True)
+    print(etree.tostring(xtree, pretty_print=True))
     xrefs = root.get_xref_dict()
-    print xrefs
+    print(xrefs)
     root.set_numbers()
     root.set_titles()
     
-    print tax.switch_species
-    print n1.get_species()
-    print n1.get_genus()
-    print n1.get_family()
+    print(tax.switch_species)
+    print(n1.get_species())
+    print(n1.get_genus())
+    print(n1.get_family())
     
 if __name__ == '__main__':
 #    import logging.config

--- a/latextree/parser.py
+++ b/latextree/parser.py
@@ -70,15 +70,15 @@ from pylatexenc.latexwalker import (
     LatexGroupNode
 )
 
-import walker
-import taxonomy as tax
+from . import walker
+from . import taxonomy as tax
 
-from node import LatexTreeNode, Macro, Environment, Switch
-from content import Content, Xref, Url, Image, Media, Latex, Comment, Text, Points
-from factory import ClassFactory, NodeFactory
-from tabular import Tabular, Row, Cell
-from bibliography import Bibliography
-from document import LatexDocument
+from .node import LatexTreeNode, Macro, Environment, Switch
+from .content import Content, Xref, Url, Image, Media, Latex, Comment, Text, Points
+from .factory import ClassFactory, NodeFactory
+from .tabular import Tabular, Row, Cell
+from .bibliography import Bibliography
+from .document import LatexDocument
 
 import logging
 logger = logging.getLogger(__name__)
@@ -667,7 +667,7 @@ class LatexParser(object):
             # elif (walker_nodelist[idx].isNodeType(LatexMacroNode) and
             #         walker_nodelist[idx].macroname in tax.switches):
             #     switchname = walker_nodelist[idx].macroname
-            #     print '***********************%s' % walker_nodelist[idx].macroname
+            #     print('***********************%s' % walker_nodelist[idx].macroname)
             
             # otherwise just take next one
             else:
@@ -735,7 +735,7 @@ class LatexParser(object):
         The parse_latex_document function bypasses this function and 
         creates the root node according to \documentclass (Article, Book etc.)
         '''
-        from preprocessor import LatexPreProcessor
+        from .preprocessor import LatexPreProcessor
         pp = LatexPreProcessor()
         text = pp.preprocess(text)
         walker_nodes = walker.parse(text)
@@ -753,7 +753,7 @@ class LatexParser(object):
         '''        
         #--------------------
         # preprocess
-        from preprocessor import LatexPreProcessor
+        from .preprocessor import LatexPreProcessor
         pp = LatexPreProcessor()
         text = pp.preprocess(text)
 
@@ -827,7 +827,7 @@ class LatexParser(object):
         filename = os.path.abspath(filename) if filename else None
         if filename:
             self.filename = filename
-            import reader
+            from . import reader
             text = reader.read_latex_document(filename)
             doc = self.parse_latex_document(text, **kwargs)
             doc.head['filename'] = filename
@@ -968,29 +968,29 @@ def main(args=None):
     pa = LatexParser()
     
     for idx, text in enumerate(tests):
-        print '=================================='
-        print 'TEST %d' % idx
+        print('==================================')
+        print('TEST %d' % idx)
         root = pa.parse_latex(text,
                 insert_strict_braces=True,
                 non_breaking_spaces=True,
             )
 
-        print '------------------------'
+        print('------------------------')
         from lxml import etree
-        print etree.tostring(root.get_xml(), pretty_print=True)
+        print(etree.tostring(root.get_xml(), pretty_print=True))
         # from lxml.html import tostring
-        # print tostring(root.get_xml(), pretty_print=True)
-        print '------------------------'
-        print root.children
-        print '------------------------'
+        # print(tostring(root.get_xml(), pretty_print=True))
+        print('------------------------')
+        print(root.children)
+        print('------------------------')
         text2 = root.get_latex()
         text  = ''.join([x.strip() for x in text.split('\n')])
         text2  = ''.join([x.strip() for x in text2.split('\n')])
-        print text
-        print '--------------'
-        print text2
-        print text == text2
-        print '--------------'
+        print(text)
+        print('--------------')
+        print(text2)
+        print(text == text2)
+        print('--------------')
 
 
     return None
@@ -1009,18 +1009,18 @@ def main(args=None):
 
     # xml output
     from lxml import etree
-    print etree.tostring(doc.root.get_xml(), pretty_print=True)
+    print(etree.tostring(doc.root.get_xml(), pretty_print=True))
 
     # info
-    print '--------------------'
-    print doc.preamble
-    print '--------------------'
-    print doc.xrefs
-    print '--------------------'
-    print doc.images
-    print '--------------------'
-    print doc.root.get_phenotypes('figure')
-    print '--------------------'
+    print('--------------------')
+    print(doc.preamble)
+    print('--------------------')
+    print(doc.xrefs)
+    print('--------------------')
+    print(doc.images)
+    print('--------------------')
+    print(doc.root.get_phenotypes('figure'))
+    print('--------------------')
 
 
 if __name__ == '__main__':

--- a/latextree/preprocessor.py
+++ b/latextree/preprocessor.py
@@ -58,7 +58,7 @@ class LatexPreProcessor(object):
             idx = match.end()
             if text[idx] != '{':
                 logger.error('The first character should be a "{"')
-                print 'First character should be a "{" at position %s' % idx
+                print('First character should be a "{" at position %s' % idx)
                 continue
 
             # find the closing brace
@@ -123,7 +123,7 @@ def main(args=None):
     '''
 #    # parse to create LatexTree
     pp = LatexPreProcessor()
-    print pp.expand_defs(s)
+    print(pp.expand_defs(s))
     
 if __name__ == '__main__':
     main()

--- a/latextree/settings.py
+++ b/latextree/settings.py
@@ -49,7 +49,7 @@ mathjax_config  = '''
     '''
 
 if __name__ == '__main__':
-    print BASE_DIR
-    print STATIC_ROOT
-    print TEMPLATE_ROOT
-    print LATEX_ROOT
+    print(BASE_DIR)
+    print(STATIC_ROOT)
+    print(TEMPLATE_ROOT)
+    print(LATEX_ROOT)

--- a/latextree/tabular.py
+++ b/latextree/tabular.py
@@ -3,8 +3,8 @@ tabular.py
 We deal with tabular environments directly (rather than via latexwalker
 """
 
-import walker
-from node import LatexTreeNode
+from . import walker
+from .node import LatexTreeNode
 
 import logging
 logger = logging.getLogger(__name__)
@@ -111,7 +111,7 @@ def main(args=None):
     # not being parsed as attributes. The LatexTreeNode.get_xml()
     # function will have to be expanded. It was only a quick hack anyway!
     from lxml import etree
-    print etree.tostring(tab.get_xml(), pretty_print=True)
+    print(etree.tostring(tab.get_xml(), pretty_print=True))
     
 if __name__ == '__main__':
     main()

--- a/latextree/walker.py
+++ b/latextree/walker.py
@@ -57,12 +57,14 @@ from pylatexenc.latexwalker import (
 
 from pylatexenc.latexwalker import LatexWalker, MacrosDef, LatexWalkerError
 
+from six import string_types
+
 import logging
 log = logging.getLogger(__name__)
 
 # import dispmath environment names
-import taxonomy as tax
-import macrosdef
+from . import taxonomy as tax
+from . import macrosdef
 
 def show_node(node, depth=0):
     '''
@@ -74,19 +76,19 @@ def show_node(node, depth=0):
     
     # non-leaf nodes    
     if type(node) == LatexMacroNode:
-        print istr*depth + 'MACRO: ' + node.macroname
+        print(istr*depth + 'MACRO: ' + node.macroname)
         if node.nodeoptarg:
             show_node(node.nodeoptarg,depth=depth+1)
         for child in node.nodeargs:
             show_node(child,depth=depth+1)
 
     elif type(node) == LatexMathNode:
-        print istr*depth + 'MATH (' + node.displaytype + '): '
+        print(istr*depth + 'MATH (' + node.displaytype + '): ')
         for child in node.nodelist:
             show_node(child,depth=depth+1)
         
     elif type(node) == LatexEnvironmentNode:
-        print istr*depth + 'ENV: ' + node.envname
+        print(istr*depth + 'ENV: ' + node.envname)
         for child in node.nodelist:
             show_node(child,depth=depth+1)
         
@@ -96,15 +98,15 @@ def show_node(node, depth=0):
 
     elif type(node) == LatexCommentNode:
         if not node.comment.isspace():
-            print istr*depth + 'COMMENT: ' + node.comment
+            print(istr*depth + 'COMMENT: ' + node.comment)
         
     elif type(node) == LatexCharsNode:
         if not node.chars.isspace():
-            print istr*depth + 'CHARS: ' + node.chars.strip()
+            print(istr*depth + 'CHARS: ' + node.chars.strip())
         
    # unknown nodes
     elif node != None:
-        print 'NODE TYPE NOT RECOGNISED: %s (%s)' % (str(node), type(node))
+        print('NODE TYPE NOT RECOGNISED: %s (%s)' % (str(node), type(node)))
         
  
 def put_in_braces(brace_char, thestring):
@@ -189,7 +191,7 @@ def macro_node_to_latex(wnode):
         
     # sanity check
     if wnode.macroname == '[':
-        print "THIS SHOULD NOT HAPPEN!"
+        print("THIS SHOULD NOT HAPPEN!")
     
     # set macro name
     macroname = wnode.macroname
@@ -199,7 +201,7 @@ def macro_node_to_latex(wnode):
     braces = '{'*len(wnode.nodeargs)
     if wnode.macroname in macrosdef.macro_dict:
         macro = macrosdef.macro_dict[wnode.macroname]
-        if isinstance(macro.numargs, basestring):
+        if isinstance(macro.numargs, string_types):
             braces = macro.numargs
         elif macro.optarg:
             braces = '{'*macro.numargs
@@ -421,7 +423,7 @@ def parse(text, **kwargs):
 
 #------------------------------------------------
 def main(args=None):
-    print 'walker.py'
+    print('walker.py')
 
     import pprint
     pp = pprint.PrettyPrinter(indent=4)
@@ -576,22 +578,22 @@ def main(args=None):
         
     # iterate over tests    
     for idx, s in enumerate(tests):
-        print '=================================='
-        print 'TEST %d' % idx
-        print s
+        print('==================================')
+        print('TEST %d' % idx)
+        print(s)
         wnodes = parse(s)      
         s2 = nodelist_to_latex(wnodes,
             non_breaking_spaces = False,
             insert_strict_braces = False,
             strict_display_maths = False,
         )        
-        print '------------------------'
-        print wnodes
-        print '------------------------'
-        print s2
-        print '------------------------'
-        print (s == s2)
-        print '------------------------'
+        print('------------------------')
+        print(wnodes)
+        print('------------------------')
+        print(s2)
+        print('------------------------')
+        print((s == s2))
+        print('------------------------')
     
     
     

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(name='latextree',
         'pylatexenc',
         'bibtexparser',
         'lxml',
+        'six',
     ],
     entry_points = {
         'console_scripts': ['ltree=latextree.ltree:main'],


### PR DESCRIPTION
Main points:

* print("hi") instead of print "hi"
* `from . import module` instead of `import module` - the path
  searching is more strict now
* encode strings before writing to file
* basestring doesn't exist - six.string_types works in both py2 and
  py3

I've run this in Python 3.5 and 2.7 and both seemed to work.